### PR TITLE
Set docs site description for previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,10 +20,7 @@
 
 title: YourBase Docs
 email: hi@yourbase.io
-# description: >- # this means to ignore newlines until "baseurl:"
-#   Write an awesome description for your new site here. You can edit this
-#   line in _config.yml. It will appear in your document head meta (for
-#   Google search results) and in your feed.xml site description.
+description: Learn how to shorten test times by up to 90% using YourBase Test Acceleration
 baseurl: "" # the subpath of your site, e.g. /blog
 url: https://docs.yourbase.io
 domain: docs.yourbase.io


### PR DESCRIPTION
Tested that description shows up in preview now:
![image](https://user-images.githubusercontent.com/82620675/131721482-1d71e24d-a5bc-4323-ade5-aa570d19f77e.png)
