### PR TITLE
Add Testify instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -271,6 +272,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   1.17.2
+   2.2.32

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Public documentation
+
+This holds the source for the [docs.yourbase.io][docs.yourbase.io] site. It is
+automatically deployed on merges to `main`.
+
+## Running locally
+
+To run docs locally, use
+
+```sh
+yb exec
+```
+
+or to run without `yb`,
+
+```sh
+bundle install
+bundle exec jekyll serve --livereload --config _config.yml,_config_dev.yml
+```
+
+[docs.yourbase.io]: https://docs.yourbase.io

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -7,4 +7,5 @@ permalink: /getting-started
 ---
 
 # Getting started
-This section gives an introduction on how to get started with running YourBase Test Acceleration in supported testing frameworks. For a full walkthrough of the tool, [see here](pytest.md).
+This section gives an introduction on how to get started with running YourBase Test
+Acceleration in supported testing frameworks.

--- a/getting-started/pytest.md
+++ b/getting-started/pytest.md
@@ -1,15 +1,19 @@
 ---
 layout: default
-title: Pytest
+title: pytest
 nav_order: 1
 parent: Getting started
 permalink: /getting-started/pytest
 ---
 
-# Try in pytest
+# pytest + YourBase
 {:.no_toc}
 
-This page will walk you through how to run YourBase Test Acceleration with the [pytest testing framework](https://docs.pytest.org/en/6.2.x/). The quickest way to get started with it is to use it in the sample project provided.
+On this page you'll learn how to accelerate your [pytest][pytest] tests with YourBase.
+The quickest way to get started is to use a sample project; in this guide, we'll use the
+open source project for the Unleash Python client.
+
+[pytest]: https://pytest.org
 
 Table of contents
 {: .text-delta }
@@ -25,17 +29,15 @@ YourBase Test Acceleration’s pytest hooks ensure that, by default:
 - It runs without any additional configuration.
 - It runs irrespective of how you invoke the tests to run—be it via Makefile, Docker, or anything else—without any other setup.
 
----
-
 ## Prerequisites
-Make sure that, on your machine or on your virtual environment:
-- Tests are running successfully with [pytest](https://docs.pytest.org/en/6.2.x/) before installing YourBase Test Acceleration.
-- [YourBase Test Acceleration is installed](../install.md).
-- [Git is installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+- Make sure tests are running successfully with pytest before installing YourBase.
+- [Install YourBase][install].
+- Your project must use Git and must have at least one commit. Git must be installed.
+- Your Git workspace should be clean.
 
----
+[install]: ../install.md
 
-## Example usage in a sample project
+## Enable acceleration for a sample project
 
 ### Step 1: Set up the specified sample project on your machine as shown below:
 {:.no_toc}

--- a/getting-started/testify.md
+++ b/getting-started/testify.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Testify
+nav_order: 3
+parent: Getting started
+permalink: /getting-started/testify
+---
+
+# Testify + YourBase
+{:.no_toc}
+
+On this page you'll learn how to accelerate your [Testify][testify] tests with YourBase.
+For a more in-depth acceleration walkthrough using a sample project, see [our pytest
+page](pytest.md).
+
+[testify]: https://github.com/yelp/testify
+
+Table of contents
+{: .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Prerequisites
+- Make sure tests are running successfully with Testify before installing YourBase.
+- [Install YourBase][install].
+- Your project must use Git and must have at least one commit. Git must be installed.
+- Your Git workspace should be clean.
+
+[install]: ../install.md
+
+## Enable acceleration for your project
+
+### Step 1: Run your project's tests with the wrapped Testify CLI
+{:.no_toc}
+[step-1]: #step-1-run-your-projects-tests-with-the-wrapped-testify-cli
+
+YourBase supplies a wrapper for the Testify command-line tool that serves as a drop-in
+replacement which applies acceleration.
+
+_Note: If your tests are going to take a while to run, you can run just a subset of your
+tests. Running a subset of tests will create a dependency graph just for those tests, so
+you can see YourBase Test Acceleration in action more quickly._
+
+To use it, replace invocations of `testify` with `yourbase testify`:
+
+```sh
+# Old
+testify <files ...>
+
+# New
+yourbase testify <files ...>
+```
+
+#### Using with Coverage.py
+{:.no_toc}
+
+If you use use Testify with Coverage.py, instead replace the command like so:
+
+```sh
+# Old
+coverage run -m testify.test_program <files ...>
+
+# New
+coverage run -m yourbase.plugins.testify <files ...>
+```
+
+### Step 2: Re-run your project's tests
+{:.no_toc}
+
+Without making a code change, run your tests again using the same command as in [step
+1][step-1].
+
+You'll see that no tests are run. Since no code was changed since the last test run,
+YourBase Test acceleration ensures that no tests are run.
+
+_Note: When Testify runs no tests, it may exit nonzero and use the word "ERROR" to
+describe the results. This is normal Testify behavior, but the `yourbase` wrapper will
+override it in a future update._
+
+### Step 3: Make a code change that would affect a test
+{:.no_toc}
+
+We've seen that YourBase can skip tests when they're not affected by code changes. Let's
+now see that it can run tests when they are!
+
+Make a change to a function that gets called (directly or indirectly) by one or more
+tests. The change can be as simple as adding a print statement like:
+
+```python
+print("Checking YourBase Test Acceleration after a code change...")
+``` 
+
+
+### Step 4: Run your tests again
+{:.no_toc}
+
+Use the same command as in [step 1][step-1] to run your tests. Here, YourBase Test
+acceleration ensures the tests that depend on the changed function run, and others
+don't.

--- a/getting-started/unittest.md
+++ b/getting-started/unittest.md
@@ -1,15 +1,19 @@
 ---
 layout: default
-title: Unittest
+title: unittest
 nav_order: 2
 parent: Getting started
 permalink: /getting-started/unittest
 ---
 
-# Try in unittest
+# unittest + YourBase
 {:.no_toc}
 
-This section notes how to run YourBase Test Acceleration in your own project that uses the [unittest testing framework](https://docs.python.org/3/library/unittest.html). For a deeper walkthrough of the library using a sample project, [see here](pytest.md).
+On this page you'll learn how to accelerate your [unittest][unittest] tests with
+YourBase. For a more in-depth acceleration walkthrough using a sample project, see [our
+pytest page](pytest.md).
+
+[unittest]: https://docs.python.org/3/library/unittest.html
 
 Table of contents
 {: .text-delta }
@@ -20,16 +24,17 @@ Table of contents
 ---
 
 ## Prerequisites
-Make sure that, on your machine or on your virtual environment:
-- Tests are running successfully with [unittest](https://docs.python.org/3/library/unittest.html) before installing YourBase Test Acceleration.
-- [YourBase Test Acceleration is installed](../install.md).
-- [Git is installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+- Make sure tests are running successfully with unittest before installing YourBase.
+- [Install YourBase][install].
+- Your project must use Git and must have at least one commit. Git must be installed.
+- Your Git workspace should be clean.
 
----
+[install]: ../install.md
 
-## Example usage in your project
 
-### Step 1: Attach yourbase to unittest.
+## Enable acceleration for your project
+
+### Step 1: Attach yourbase to unittest
 {:.no_toc}
 
 In your `tests/__init__.py file`, copy-paste the following:
@@ -43,31 +48,44 @@ yourbase.attach(unittest)
 
 ### Step 2: Run your project’s tests
 {:.no_toc}
+[step-2]: #step-2-run-your-projects-tests
 
 For example, to run all the tests for the project, use:
 ```sh
 python -m unittest discover
 ```
 
-_Note: If your tests are going to take a while to run, you can run just a subset of your tests. Running a subset of tests will create a dependency graph just for those tests, so you can see YourBase Test Acceleration in action more quickly._
+_Note: If your tests are going to take a while to run, you can run just a subset of your
+tests. Running a subset of tests will create a dependency graph just for those tests, so
+you can see YourBase Test Acceleration in action more quickly._
 
 
 ### Step 3: Re-run your tests
 {:.no_toc}
 
-Without making a code change, run your tests again using the same command as in [step #2](#step-2-run-your-projects-tests). You'll see that no tests are run. Here, since no code was changed, YourBase Test acceleration ensures that no tests are run.
+Without making a code change, run your tests again using the same command as in [step
+2][step-2].
 
-### Step 4: Make a code change in any one of your tests
+You'll see that no tests are run. Since no code was changed since the last test run,
+YourBase Test acceleration ensures that no tests are run.
+
+### Step 4: Make a code change that would affect a test
 {:.no_toc}
 
-You can simply add a print statement like below:
+We've seen that YourBase can skip tests when they're not affected by code changes. Let's
+now see that it can run tests when they are!
+
+Make a change to a function that gets called (directly or indirectly) by one or more
+tests. The change can be as simple as adding a print statement like:
 
 ```python
-print(“Checking YourBase Test Acceleration after a code-change...”)
+print("Checking YourBase Test Acceleration after a code change...")
 ``` 
 
 
 ### Step 5: Run your tests again
 {:.no_toc}
 
-Use the same command as in [step #2](#step-2-run-your-projects-tests) to run your tests. Here, YourBase Test acceleration ensures that only the one test that you modified is run.
+Use the same command as in [step 1][step-1] to run your tests. Here, YourBase Test
+acceleration ensures the tests that depend on the changed function run, and others
+don't.

--- a/install.md
+++ b/install.md
@@ -20,79 +20,29 @@ Table of contents
 ## Prerequisites
 Make sure that the YourBase Test Acceleration library [supports your technical stack and infrastructure](system-requirements.md).
 
----
-
 ## Installation
 
-YourBase Test Acceleration library can be installed with either [pip](https://pip.pypa.io/en/stable/) or [poetry](https://python-poetry.org/docs/) package managers.
-
-
-### Using pip
-If you use [pip](https://pip.pypa.io/en/stable/), you can install YourBase Test Acceleration with:
+YourBase Test Acceleration can be installed with your standard Python package manager,
+e.g. [pip](https://pip.pypa.io/en/stable/) or [poetry](https://python-poetry.org/docs/).
 
 ```sh
+# pip
 pip install yourbase
+# poetry
+poestry add yourbase
 ```
 
-To check if YourBase Test Acceleration is installed, run the following command in a shell prompt:
+Alternatively, add `yourbase` to your `requirements.txt` or similar.
 
-```sh
-pip show yourbase
-```
-
-If the installation is successful, you should see an output similar to what’s shown below, having a Version key that displays a valid version of YourBase Test Acceleration.
- 
-```sh
-Name: yourbase
-Version: 5.2.4
-Summary: Skip tests based on tracing data
-Home-page: https://yourbase.io
-Author: YourBase Test Acceleration
-Author-email: python@yourbase.io
-License: UNKNOWN
-Location: /Path/Python/3.8/lib/python/site-packages
-Requires: six, boto3, python-dateutil, coverage, pastel, requests
-Required-by:
-```
-
----
-
-### Using poetry
-If you use [poetry](https://python-poetry.org/docs/), you can install YourBase Test Acceleration with:
-
-```sh
-poetry add yourbase
-```
-
-To check if YourBase Test Acceleration is installed, run the following command in a shell prompt:
-
-```sh
-poetry show yourbase
-```
-
-If the installation is successful, you should see an output similar to what’s shown below, having a Version key that displays a valid version of YourBase Test Acceleration.
-
-```sh
-Name: yourbase
-Version: 5.2.4
-Summary: Skip tests based on tracing data
-Home-page: https://yourbase.io
-Author: YourBase Test Acceleration
-Author-email: python@yourbase.io
-License: UNKNOWN
-Location: /Path/Python/3.8/lib/python/site-packages
-Requires: six, boto3, python-dateutil, coverage, pastel, requests
-Required-by:
-```
-
----
 
 ## Recommendations
 
-### Use virtual environment
+### Use a virtual environment
 {: .no_toc }
 
-We recommend that you install YourBase Test Acceleration in a clean virtual environment. [Learn to set up a Python virtual environment here](https://docs.python.org/3/tutorial/venv.html).
+We recommend that you install YourBase Test Acceleration in a clean virtual environment.
+[Learn to set up a Python virtual environment
+here](https://docs.python.org/3/tutorial/venv.html).
 
 ---
 
@@ -102,12 +52,9 @@ If for any reason, you want to completely remove YourBase Test Acceleration, sim
 Using [pip](https://pip.pypa.io/en/stable/): 
 
 ```sh
+# pip
 pip uninstall yourbase
-```
-
-Or, using [poetry](https://python-poetry.org/docs/):
-
-```sh
+# poetry
 poetry remove yourbase
 ```
 


### PR DESCRIPTION
Adds a page of instructions for running with Testify, next to the pytest and unittest pages.

Also:
- Adds a README
- Fixes a Ruby 3 dependency issue with running Jekyll
- Makes some instructions more consistent across pytest/unittest/Testify pages
- Simplifies some installation instructions (e.g. verifying install w/pip vs. w/poetry -- for our customers this is day-to-day knowledge so doesn't need to be said)