### PR TITLE
Add DeleteObjects to required permissions

### DIFF
--- a/advanced-usage/accelerate-tests-in-ci.md
+++ b/advanced-usage/accelerate-tests-in-ci.md
@@ -7,46 +7,74 @@ permalink: /advanced-usage/accelerate-tests-in-ci
 ---
 
 # Integrate with CI
-YourBase Test Acceleration uses a [dependency graph](../how-it-works.md#dependency-graph) to accelerate your tests. When you run tests on your local machine, with YourBase Test Acceleration enabled, by default, your dependency graph is stored locally—thus provides only for local acceleration.
+YourBase Test Acceleration uses a [dependency
+graph](../how-it-works.md#dependency-graph) to accelerate your tests. When you run tests
+on your local machine with YourBase Test Acceleration enabled, by default your
+dependency graph is stored locally and cannot benefit runs on other machines.
 
-But the true power of YourBase Test Acceleration comes in when tests can be accelerated in your CI environment. This requires the [dependency graph](../how-it-works.md#dependency-graph) to be accessible by your CI environment—referred to as [Shared Dependency Graph](../how-it-works.md#shared-dependency-graph) from now on.
+The true power of YourBase Test Acceleration shows when tests can be accelerated in your
+CI environment. This requires that a [dependency
+graph](../how-it-works.md#dependency-graph) be accessible by your CI environment even
+when the environment is constantly torn down and rebuilt. We call this a [shared
+dependency graph](../how-it-works.md#shared-dependency-graph).
 
-The following section guides you to accelerate tests in CI.
+On this page, you'll learn how to accelerate tests in CI using a shared dependency
+graph.
 
 ## Steps to integrate with CI
 
-### Step 1: Set up shared dependency graph
-YourBase Test Acceleration currently supports storing [shared dependency graphs](../how-it-works.md#shared-dependency-graph) only in AWS S3 buckets. The following sections help you set up your project to use a shared dependency graph in your CI environment.
+### Step 1: Set up a shared dependency graph
+YourBase Test Acceleration supports storing [shared dependency
+graphs](../how-it-works.md#shared-dependency-graph) only in AWS S3 buckets.
 
-1. Set [YOURBASE_REMOTE_CACHE](../environment-variables.md#yourbase_remote_cache)  in your environment to a valid S3 bucket location.
+1.  Set [`YOURBASE_REMOTE_CACHE`](../environment-variables.md#yourbase_remote_cache) in
+    your environment to a valid S3 bucket location.
 
     ```sh
     YOURBASE_REMOTE_CACHE=s3://<bucketname>[/key/prefix]
-    
-    # where <bucketname> is an S3 bucket that your machine(s) has Get/Put/List access to.
+
+    # e.g.
+    YOURBASE_REMOTE_CACHE=s3://mycompany-build-artifacts/ci
     ```
 
-2. Set the AWS credentials to be used by YourBase Test Acceleration.
+    YourBase will store its artifacts in a `/yourbase` "directory" inside the path you
+    specify.
 
-   By default, YourBase Test Acceleration uses the system AWS credentials as specified in the environment variables: [AWS_ACCESS_KEY_ID](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list) and [AWS_SECRET_ACCESS_KEY](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list). 
-   
-   Alternately, you can specify different credentials to be used exclusively by YourBase Test Acceleration by setting the following environment variables:
-   
-   ```sh
-   export YOURBASE_AWS_ACCESS_KEY_ID=<key>
-   export YOURBASE_AWS_SECRET_ACCESS_KEY=<key>
+2. Set the AWS credentials to be used by YourBase Test Acceleration. YourBase requires
+   these permissions to use your bucket:
    ```
-       
-   _Note: If YourBase Test Acceleration specific environment variables - [YOURBASE_AWS_ACCESS_KEY_ID](../environment-variables.md#yourbase_aws_access_key_id) and [YOURBASE_AWS_SECRET_ACCESS_KEY](../environment-variables.md#yourbase_aws_secret_access_key) are set, YourBase Test Acceleration uses them instead of the system credentials._
+   s3:GetObject
+   s3:PutObject
+   s3:DeleteObjects
+   s3:ListObjects
+   s3:ListObjectsV2
+   ```
+
+   By default, your [system credentials][aws-system-credentials] are used. If you mock
+   your system credentials for your test suite, you may need to specify non-mocked
+   credentials exclusively for YourBase. You can do this by setting
+   [`YOURBASE_AWS_ACCESS_KEY_ID`][YOURBASE_AWS_ACCESS_KEY_ID] and
+   [`YOURBASE_AWS_SECRET_ACCESS_KEY`][YOURBASE_AWS_SECRET_ACCESS_KEY].
+
+   [aws-system-credentials]:
+   https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+   [YOURBASE_AWS_ACCESS_KEY_ID]: ../environment-variables.md#yourbase_aws_access_key_id
+   [YOURBASE_AWS_SECRET_ACCESS_KEY]: ../environment-variables.md#yourbase_aws_secret_access_key
 
 ### Step 2: Install YourBase Test Acceleration in your CI environment
-Add YourBase Test Acceleration to your project via `requirements.txt` or whatever other mechanism you use to install your dependencies in your CI environment.
+Add YourBase Test Acceleration to your project according to the [instructions for your
+language and testing framework][install-yourbase].
+
+[install-yourbase]: ../getting-started
 
 ### Step 3: Run tests
 Run tests as usual.
 
 ## That's it!
-The above steps will set up YourBase Test Acceleration to synchronize dependency graphs against the specified storage location when your tests run on your CI environment.
+The above steps will set up YourBase Test Acceleration to synchronize dependency graphs
+to the specified storage location when your tests run on your CI environment. Future
+runs will use the storage location as the source for their dependency graph,
+accelerating runs even when the environment is brand new.
 
 _Note:_
 _A dependency graph is synchronized with the specified remote storage location:_

--- a/environment-variables.md
+++ b/environment-variables.md
@@ -8,75 +8,91 @@ permalink: /environment-variables
 # Environment variables
 {: .no_toc }
 
-Environment variables provide another way to specify configuration options and credentials.
+Environment variables provide another way to specify configuration options and
+credentials.
 
-YourBase Test Acceleration supports the following environment variables. You should set them in same way you set other environment variables for your deployment.
+YourBase Test Acceleration supports the following environment variables. You should set
+them in same way you set other environment variables for your deployment.
 
 - TOC
 {:toc}
 
 ---
 
-## YOURBASE_ACCEPT_TOS
-Type: `bool-ish (0, false, off, 1, true, on)`
+## `YOURBASE_ACCEPT_TOS`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
-Default: `off`
-
-When set, YourBase Test Acceleration will consider the terms of service permanently accepted for your organization, and will not output terms of service agreement prompts or info messages. This is helpful, for example, when rolling out YourBase Test Acceleration to CI for an organization.
-
----
-
-## YOURBASE_ACTIVE_COHORT
-Type: `integer` in the range `[1, $YOURBASE_COHORT_COUNT]`
-
-Default: `1`
-
-When set alongside [YOURBASE_COHORT_COUNT](#yourbase_cohort_count), tells YourBase Test Acceleration the cohort ID to run. Used for sharded or otherwise parallelized test suites.
-
-See [here](advanced-usage/accelerate-parallelized-tests.md) to learn to use this in your parallelized test-suite. 
-
---- 
-
-## YOURBASE_COHORT_COUNT
-Type: `integer`
-
-Default: `1`
-
-When set alongside [YOURBASE_ACTIVE_COHORT](#yourbase_active_cohort), tells YourBase Test Acceleration how many cohorts the tests should be split into.
-
-This pair of settings lets YourBase Test Acceleration work with your existing sharding or parallelization setup. See here to [learn to use it in your parallelized test setup](advanced-usage/accelerate-parallelized-tests.md).
+When set, YourBase Test Acceleration will consider the terms of service permanently
+accepted for your organization, and will not output terms of service agreement prompts
+or info messages. This is helpful, for example, when rolling out YourBase Test
+Acceleration to CI for an organization.
 
 ---
 
-## YOURBASE_LICENSE_KEY
-Type: `opaque string`
+## `YOURBASE_ACTIVE_COHORT`
+- Type: integer
+- Range: `[1, $YOURBASE_COHORT_COUNT]`
+- Default: `1`
 
-Default: `(unset)`
+When set alongside [YOURBASE_COHORT_COUNT](#yourbase_cohort_count), tells YourBase Test
+Acceleration the cohort ID to run. Used for sharded or otherwise parallelized test
+suites.
 
-When set to a valid license key, YourBase Test Acceleration will be unlocked for use after the end of the free trial. Email [hi@yourbase.io](mailto:hi@yourbase.io) to obtain a license key.
-
----
-
-## YOURBASE_OBSERVATION_MODE
-Type: `bool-ish (0, false, off, 1, true, on)`
-
-Default: `off`
-
-When on, YourBase Test Acceleration will not skip tests, and instead, only record the duration and outcome of each test it believes should be skipped. 
-
-When this setting is off, YourBase Test Acceleration will optimize your test run-time as usual.
-
-It’s useful to turn this setting on when you’re testing YourBase Test Acceleration before taking it live with your codebase. Learn more about [how to use the Observation mode here](advanced-usage/verify-results.md).
+See [here](advanced-usage/accelerate-parallelized-tests.md) to learn to use this in your
+parallelized test-suite.
 
 ---
 
-## YOURBASE_REMOTE_CACHE
-Type: `uri`
+## `YOURBASE_COHORT_COUNT`
+- Type: integer
+- Range: `[1, ∞)`
+- Default: `1`
 
-Default: `(unset)`
+When set alongside [YOURBASE_ACTIVE_COHORT](#yourbase_active_cohort), tells YourBase
+Test Acceleration how many cohorts the tests should be split into.
+
+This pair of settings lets YourBase Test Acceleration work with your existing sharding
+or parallelization setup. See here to [learn to use it in your parallelized test
+setup](advanced-usage/accelerate-parallelized-tests.md).
+
+---
+
+## `YOURBASE_LICENSE_KEY`
+- Type: opaque string
+- Default: _(unset)_
+
+When set to a valid license key, YourBase Test Acceleration will be unlocked for use
+after the end of the free trial. Email [hi@yourbase.io](mailto:hi@yourbase.io) to obtain
+a license key.
+
+---
+
+## `YOURBASE_OBSERVATION_MODE`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
+
+When on, YourBase Test Acceleration will not skip tests, and instead, only record the
+duration and outcome of each test it believes should be skipped.
+
+When this setting is off, YourBase Test Acceleration will optimize your test run-time as
+usual.
+
+It’s useful to turn this setting on when you’re testing YourBase Test Acceleration
+before taking it live with your codebase. Learn more about [how to use the Observation
+mode here](advanced-usage/verify-results.md).
+
+---
+
+## `YOURBASE_REMOTE_CACHE`
+- Type: URI
+- Default: _(unset)_
 
 
-When set, this synchronizes [dependency graphs](how-it-works.md#dependency-graph) generated only from clean working trees—dependency graphs generated from dirty working trees will not be synchronized as they can poison the cache. Use [YOURBASE_SYNC_DIRTY](#yourbase_sync_dirty) to override this behavior.
+When set, this synchronizes [dependency graphs](how-it-works.md#dependency-graph)
+generated from clean working trees to the given remote location.—dependency graphs
+generated from dirty working trees will not be synchronized as they can poison the
+cache. Use [YOURBASE_SYNC_DIRTY](#yourbase_sync_dirty) to override this behavior.
 
 ```sh
 # Without a key prefix
@@ -88,129 +104,152 @@ export YOURBASE_REMOTE_CACHE=s3://my-bucket-name
 export YOURBASE_REMOTE_CACHE=s3://my-bucket-name/my/key/prefix
 ```
 
-This setting is recommended for use when using YourBase Test Acceleration in CI, as the filesystem will not be a dependable store for [dependency graphs](how-it-works.md#dependency-graph). Learn to [set up a shared dependency graph in your CI here](advanced-usage/accelerate-tests-in-ci.md).
+This setting is recommended for use when using YourBase Test Acceleration in CI, as the
+filesystem will not be a dependable store for [dependency
+graphs](how-it-works.md#dependency-graph). Learn to [set up a shared dependency graph in
+your CI here](advanced-usage/accelerate-tests-in-ci.md).
 
 ---
 
-## YOURBASE_AWS_ACCESS_KEY_ID
-Type: `AWS access key ID`
+## `YOURBASE_AWS_ACCESS_KEY_ID`
+- Type: AWS access key ID
+- Default: _(unset)_
 
-Default: `(unset)`
+When set alongside [YOURBASE_AWS_SECRET_ACCESS_KEY](#yourbase_aws_secret_access_key),
+forces YourBase Test Acceleration to use these credentials over system credentials when
+interacting with AWS.
 
-When set alongside [YOURBASE_AWS_SECRET_ACCESS_KEY](#yourbase_aws_secret_access_key), it forces YourBase Test Acceleration to use these credentials over system credentials when interacting with AWS.
-
-These environment variables are recommended for use if your AWS system credentials are fudged for the sake of your tests. Learn to use this [YourBase Test Acceleration specific AWS environment variables here](advanced-usage/accelerate-tests-in-ci.md#step-1-set-up-shared-dependency-graph).
-
----
-
-## YOURBASE_AWS_SECRET_ACCESS_KEY
-Type: `AWS secret access key`
-
-Default: `(unset)`
-
-When set alongside [YOURBASE_AWS_ACCESS_KEY_ID](#yourbase_aws_access_key_id), it forces YourBase Test Acceleration to use these credentials over AWS system credentials when interacting with AWS.
-
-These environment variables are recommended for use if your system credentials are mocked for the sake of your tests. Learn to use this [YourBase Test Acceleration specific AWS environment variables here](advanced-usage/accelerate-tests-in-ci.md#step-1-set-up-shared-dependency-graph)
+These environment variables are recommended for use if your AWS system credentials are
+fudged for the sake of your tests. Learn to use this [YourBase Test Acceleration
+specific AWS environment variables
+here](advanced-usage/accelerate-tests-in-ci.md#step-1-set-up-shared-dependency-graph).
 
 ---
 
-## YOURBASE_DEBUG
-Type: `bool-ish (0, false, off, 1, true, on)`
+## `YOURBASE_AWS_SECRET_ACCESS_KEY`
+- Type: AWS secret access key
+- Default: _(unset)_
 
-Default: `off`
+When set alongside [YOURBASE_AWS_ACCESS_KEY_ID](#yourbase_aws_access_key_id), forces
+YourBase Test Acceleration to use these credentials over AWS system credentials when
+interacting with AWS.
 
-When on, YourBase Test Acceleration will report significantly more internal information to stdout, stderr, and XDG (see the file returned by this expression):
+These environment variables are recommended for use if your system credentials are
+mocked for the sake of your tests. Learn to use this [YourBase Test Acceleration
+specific AWS environment variables
+here](advanced-usage/accelerate-tests-in-ci.md#step-1-set-up-shared-dependency-graph)
+
+---
+
+## `YOURBASE_DEBUG`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
+
+When on, YourBase Test Acceleration will report significantly more internal information
+to stdout, stderr, and XDG (see the file returned by this expression):
 
 ```sh
 echo ${XDG_STATE_HOME-~/.local/state}/yourbase/python.log
 ```
 
-This setting is most beneficial when collaborating with the YourBase Test Acceleration team to debug issues.
+This setting is most beneficial when collaborating with the YourBase Test Acceleration
+team to debug issues.
 
 ---
 
-## YOURBASE_GENERATE_COVERAGE
-Type: `bool-ish (0, false, off, 1, true, on)`
-
-Default: `off`
+## `YOURBASE_GENERATE_COVERAGE`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
 When on, YourBase Test Acceleration will generate a coverage database including
 coverage data from previous runs.
 
-This setting will remove the need to enable coverage via the standard pytest or
-coverage commandline options.
+This setting will remove the need to enable coverage via the standard pytest or coverage
+commandline options.
+
 ---
 
-## YOURBASE_DISABLE
-Type: `bool-ish (0, false, off, 1, true, on)`
-
-Default: `off`
+## `YOURBASE_DISABLE`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
 When on, YourBase Test Acceleration will not load.
 
-Enabling this setting and then manually attaching to a test framework using `yourbase.attach` produces undefined behavior.
+Enabling this setting and then manually attaching to a test framework using
+`yourbase.attach` produces undefined behavior.
 
 ---
 
-## YOURBASE_IGNORE_LOCAL_CACHE
-Type: `bool-ish (0, false, off, 1, true, on)`
+## `YOURBASE_IGNORE_LOCAL_CACHE`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
-Default: `off`
+When on, YourBase Test Acceleration will not look in the local filesystem for a
+[dependency graph](how-it-works.md#dependency-graph).
 
-When on, YourBase Test Acceleration will not look in the local filesystem for a [dependency graph](how-it-works.md#dependency-graph). 
+If you’ve set [YOURBASE_REMOTE_CACHE](#yourbase_remote_cache) to a valid location,
+YourBase Test Acceleration will look up and [synchronize the dependency
+graph](how-it-works.md#shared-dependency-graph) with the specified location.
 
-If you’ve set [YOURBASE_REMOTE_CACHE](#yourbase_remote_cache) to a valid location, YourBase Test Acceleration will look up and [synchronize the dependency graph](how-it-works.md#shared-dependency-graph) with the specified location. 
+Else, if [YOURBASE_REMOTE_CACHE](#yourbase_remote_cache) is not set, YourBase Test
+Acceleration will do a cold run of your tests—it will run all the tests since it won’t
+be able to find any dependency graph.
 
-Else, if [YOURBASE_REMOTE_CACHE](#yourbase_remote_cache) is not set, YourBase Test Acceleration will do a cold run of your tests—it will run all the tests since it won’t be able to find any dependency graph. 
-
-This setting can be used if the local cache is expected to be poisoned. For instance, this can happen if cohorting is used against a local cache.
-
----
-
-## YOURBASE_SYNC_DIRTY
-Type: `bool-ish (0, false, off, 1, true, on)`
-
-Default: `off`
-
-When on, YourBase Test Acceleration will [synchronize dependency graphs](how-it-works.md#shared-dependency-graph) even if the Git working tree is dirty. 
-
-This setting is not recommended for use when you run YourBase Test Acceleration locally, as it will poison the remote cache.
-
-This setting is useful when you use YourBase Test Acceleration in CI. There it can help you overcome situations where you need your working tree to be dirty while building, and you know the dirtiness will not affect the dependency graph.
-If that situation does not apply to you, do not enable this setting.
+This setting can be used if the local cache is expected to be poisoned. For instance,
+this can happen if cohorting is used against a local cache.
 
 ---
 
-## YOURBASE_TELEMETRY
-Type: `bool-ish (0, false, off, 1, true, on)`
+## `YOURBASE_SYNC_DIRTY`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
-Default: `on`
+When on, YourBase Test Acceleration will [synchronize dependency
+graphs](how-it-works.md#shared-dependency-graph) even if the Git working tree is dirty.
 
-When on, YourBase Test Acceleration will send anonymized telemetry data to `api.yourbase.io` over HTTPS for the purposes of improving the product.
-Note that, telemetry data never includes your code.
+This setting is not recommended for use when you run YourBase Test Acceleration locally,
+as it will poison the remote cache.
 
-Turn it off, if you want to opt out of sending usage statistics and error reports to YourBase Test Acceleration. 
+This setting is useful when you use YourBase Test Acceleration in CI. There it can help
+you overcome situations where you need your working tree to be dirty while building, and
+you know the dirtiness will not affect the dependency graph. If that situation does not
+apply to you, do not enable this setting.
+
+---
+
+## `YOURBASE_TELEMETRY`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `on`
+
+When on, YourBase Test Acceleration will send anonymized telemetry data to
+`api.yourbase.io` over HTTPS for the purposes of improving the product. Note that,
+telemetry data never includes your code.
+
+Turn this off if you want to opt out of sending usage statistics and error reports to
+YourBase Test Acceleration.
 
 [Learn more about telemetry data here](security.md#telemetry).
 
 ---
 
-## YOURBASE_TIMID
-Type: `bool-ish (0, false, off, 1, true, on)`
+## `YOURBASE_TIMID`
+- Type: bool (`0`, `false`, `off`, `1`, `true`, `on`)
+- Default: `off`
 
-Default: `off`
+When on, YourBase Test Acceleration will use a slower tracing algorithm that is less
+prone to conflicts with other packages than the default.
 
-When on, YourBase Test Acceleration will use a slower tracing algorithm that is less prone to conflicts with other packages than the default. 
-
-We recommend reaching out to [support@yourbase.io](mailto:support@yourbase.io) if you are encountering this scenario, and only enabling this if you experience issues with the default algorithm. 
+We recommend reaching out to [support@yourbase.io](mailto:support@yourbase.io) if you
+are encountering this scenario, and only enabling this if you experience issues with the
+default algorithm.
 
 ---
 
-## YOURBASE_WORKDIR
-Type: `absolute or relative path`
+## `YOURBASE_WORKDIR`
+- Type: path
+- Default: `.`
 
-Default: `.`
-
-This is the directory that YourBase Test Acceleration treats as the project directory. Only the code in this directory, or one of its descendants, will be traced. 
+This is the directory that YourBase Test Acceleration treats as the project directory.
+Only the code in this directory, or one of its descendants, will be traced.
 
 You usually do not need to change this, as it’s mainly for debugging purposes.


### PR DESCRIPTION
Add `DeleteObjects` to the list of S3 permissions we need, for a future CLI command to clear the remote cache.

Also made various formatting and misc. improvements to the related pages, including wrapping lines and fixing some monospace formatting.